### PR TITLE
Farmer's Delight 1.3.x API migration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,128 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+## Upload Locations
+
+### Logs & Crash Reports
+Upload to:
+https://mclo.gs
+
+### Screenshots
+Upload to:
+https://imgur.com
+
+### Large Files / Configs / Extra Files
+Upload to:
+https://catbox.moe
+
+Upload to these locations and provide the URL(s)
+This keeps the tracker much cleaner and easier to read.
+Thanks!
+
+
+
+## Bug Report
+
+### Describe the Issue
+Provide a clear description of what happened.
+
+---
+
+## Steps To Reproduce
+
+1.
+2.
+3.
+
+---
+
+## Expected Behavior
+
+What should have happened instead?
+
+---
+
+## Actual Behavior
+
+What actually happened?
+
+---
+
+## Logs & Crash Reports
+
+Please upload logs to:
+
+https://mclo.gs
+
+Required files:
+
+### Client
+- `logs/latest.log`
+- `crash-reports/<latest crash report>.txt` (if present)
+
+### Server
+- `logs/latest.log`
+- `crash-reports/<latest crash report>.txt` (if present)
+
+Please do **not** paste massive logs directly into GitHub issues.
+
+---
+
+## Environment Information
+
+### Minecraft Version
+Example:
+`1.21.1`
+
+### Mod Loader + Version
+Example:
+`NeoForge 21.1.222`
+
+### Mod Version
+Example:
+`Carry On 2.2.4.4`
+
+### Singleplayer or Dedicated Server
+- [ ] Singleplayer
+- [ ] Dedicated Server
+
+---
+
+## Additional Information
+
+### Were you carrying a block/entity when this happened?
+- [ ] Yes
+- [ ] No
+
+### Did this happen during login/joining the world?
+- [ ] Yes
+- [ ] No
+
+### Did this happen after changing dimensions?
+- [ ] Yes
+- [ ] No
+
+### Did this happen after teleporting?
+- [ ] Yes
+- [ ] No
+
+### Did this happen after dying/relogging?
+- [ ] Yes
+- [ ] No
+
+### Does this happen consistently?
+- [ ] Every time
+- [ ] Sometimes
+- [ ] Only happened once
+
+---
+
+## Screenshots
+
+If applicable, add URL to screenshots here.

--- a/.github/ISSUE_TEMPLATE/questions.md
+++ b/.github/ISSUE_TEMPLATE/questions.md
@@ -1,0 +1,10 @@
+---
+name: Questions
+about: Q&A Time!
+title: ''
+labels: question
+assignees: ''
+
+---
+
+NOTE: Read the description for the mod on Curseforge before asking your questions.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
-# End-s-Delight
-The source code of the minecraft mod End's Delight.
-current version has been reported broken for awhile now.  This is my attempt to remedy the issue
+Additional Notes for Source Builds
+
+This patched release focuses only on the runtime compatibility fixes required for NeoForge 1.21.1 + Farmers Delight 1.21 API compatibility.
+
+Implemented fixes:
+
+* Updated End Stove classes to use the new Farmers Delight stove API
+* Updated renderer inventory accessors (`getInventory()` → `getItems()`)
+* Updated milk recipe tags (`c:foods/milk` → `c:drinks/milk`)
+
+Additional compatibility cleanup exists in upstream PR #60:
+https://github.com/FoggyHillside/End-s-Delight/pull/60
+
+Those extra changes were intentionally not included in this patch jar in order to keep the runtime fix as small and isolated as possible. Users compiling from source may optionally review or incorporate those additional changes depending on their build environment and dependency versions.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+Additional Notes for Source Builds
+
+This patched release focuses only on the runtime compatibility fixes required for NeoForge 1.21.1 + Farmers Delight 1.21 API compatibility.
+
+Implemented fixes:
+
+* Updated End Stove classes to use the new Farmers Delight stove API
+* Updated renderer inventory accessors (`getInventory()` → `getItems()`)
+* Updated milk recipe tags (`c:foods/milk` → `c:drinks/milk`)
+
+Additional compatibility cleanup exists in upstream PR #60:
+https://github.com/FoggyHillside/End-s-Delight/pull/60
+
+Those extra changes were intentionally not included in this patch jar in order to keep the runtime fix as small and isolated as possible. Users compiling from source may optionally review or incorporate those additional changes depending on their build environment and dependency versions.
+
+
 # Fix NeoForge 1.21.1 Farmer’s Delight Stove API Compatibility
 
 ## Summary

--- a/README.md
+++ b/README.md
@@ -1,14 +1,34 @@
-Additional Notes for Source Builds
+# Fix NeoForge 1.21.1 Farmer’s Delight Stove API Compatibility
 
-This patched release focuses only on the runtime compatibility fixes required for NeoForge 1.21.1 + Farmers Delight 1.21 API compatibility.
+## Summary
 
-Implemented fixes:
+Updates End's Delight stove implementation to match the current Farmer’s Delight 1.21 API structure and fixes outdated milk tag references.
 
-* Updated End Stove classes to use the new Farmers Delight stove API
-* Updated renderer inventory accessors (`getInventory()` → `getItems()`)
-* Updated milk recipe tags (`c:foods/milk` → `c:drinks/milk`)
+## Changes
 
-Additional compatibility cleanup exists in upstream PR #60:
-https://github.com/FoggyHillside/End-s-Delight/pull/60
+* Updated `EndStoveBlockEntity` constructor usage.
+* Added explicit `RecipeType.CAMPFIRE_COOKING`.
+* Replaced deprecated milk tags:
 
-Those extra changes were intentionally not included in this patch jar in order to keep the runtime fix as small and isolated as possible. Users compiling from source may optionally review or incorporate those additional changes depending on their build environment and dependency versions.
+  * `c:foods/milk`
+  * with:
+  * `c:drinks/milk`
+
+## Validation
+
+Verified against:
+
+* Farmer’s Delight 1.21 source/API
+* Existing End’s Delight source structure
+* Patched production JAR
+
+Confirmed:
+
+* No unrelated bytecode changes
+* No invalid constructor calls remain
+* Stove block entity loads correctly
+* Recipe registration structure remains intact
+
+## Result
+
+Resolves compatibility issues and prevents stove-related failures caused by outdated Farmer’s Delight API usage on NeoForge 1.21.1.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # End-s-Delight
 The source code of the minecraft mod End's Delight.
+current version has been reported broken for awhile now.  This is my attempt to remedy the issue

--- a/README.md
+++ b/README.md
@@ -1,19 +1,3 @@
-Additional Notes for Source Builds
-
-This patched release focuses only on the runtime compatibility fixes required for NeoForge for Minecraft 1.21.1 + Farmers Delight - 1.21 API compatibility.
-
-Implemented fixes:
-
-* Updated End Stove classes to use the new Farmers Delight stove API
-* Updated renderer inventory accessors (`getInventory()` → `getItems()`)
-* Updated milk recipe tags (`c:foods/milk` → `c:drinks/milk`)
-
-Additional compatibility cleanup exists in upstream PR #60:
-https://github.com/FoggyHillside/End-s-Delight/pull/60
-
-Those extra changes were intentionally not included in this patch jar in order to keep the runtime fix as small and isolated as possible. Users compiling from source may optionally review or incorporate those additional changes depending on their build environment and dependency versions.
-
-
 # Fix NeoForge for Minecraft 1.21.1 Farmer’s Delight Stove API Compatibility
 
 ## Summary

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Additional Notes for Source Builds
 
-This patched release focuses only on the runtime compatibility fixes required for NeoForge 1.21.1 + Farmers Delight 1.21 API compatibility.
+This patched release focuses only on the runtime compatibility fixes required for NeoForge for Minecraft 1.21.1 + Farmers Delight - 1.21 API compatibility.
 
 Implemented fixes:
 
@@ -14,7 +14,7 @@ https://github.com/FoggyHillside/End-s-Delight/pull/60
 Those extra changes were intentionally not included in this patch jar in order to keep the runtime fix as small and isolated as possible. Users compiling from source may optionally review or incorporate those additional changes depending on their build environment and dependency versions.
 
 
-# Fix NeoForge 1.21.1 Farmer’s Delight Stove API Compatibility
+# Fix NeoForge for Minecraft 1.21.1 Farmer’s Delight Stove API Compatibility
 
 ## Summary
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,5 +22,5 @@ mod_authors=FoggyHillside
 mod_description=An addon mod for Farmer's Delight based around adding culinary content to the End!
 
 #Dependencies
-farmersdelight_version_range=[1.2.4a,)
-farmersdelight_version=5772720
+farmersdelight_version=8007613
+farmersdelight_version_range=[1.3.1,)

--- a/src/main/java/cn/foggyhillside/ends_delight/block/EndStoveBlock.java
+++ b/src/main/java/cn/foggyhillside/ends_delight/block/EndStoveBlock.java
@@ -41,7 +41,7 @@ public class EndStoveBlock extends AbstractStoveBlock
     @Nullable
     public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState state, BlockEntityType<T> blockEntityType) {
         if (level.isClientSide && state.getValue(LIT)) return createTickerHelper(blockEntityType, ModBlockEntityTypes.END_STOVE.get(), EndStoveBlockEntity::particleTick);
-        return createStoveTicker(level, blockEntityType, ModBlockEntityTypes.END_STOVE.get());
+        return AbstractStoveBlock.createStoveTicker(level, blockEntityType, ModBlockEntityTypes.END_STOVE.get());
     }
 
     @Override

--- a/src/main/java/cn/foggyhillside/ends_delight/block/EndStoveBlock.java
+++ b/src/main/java/cn/foggyhillside/ends_delight/block/EndStoveBlock.java
@@ -6,210 +6,61 @@ import com.mojang.serialization.MapCodec;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.particles.ParticleTypes;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.RandomSource;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.world.ItemInteractionResult;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.Mob;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.*;
-import net.minecraft.world.item.context.BlockPlaceContext;
-import net.minecraft.world.item.crafting.CampfireCookingRecipe;
-import net.minecraft.world.item.crafting.RecipeHolder;
-import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.*;
+import net.minecraft.world.level.block.HorizontalDirectionalBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityTicker;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.state.StateDefinition;
-import net.minecraft.world.level.block.state.properties.BlockStateProperties;
-import net.minecraft.world.level.block.state.properties.BooleanProperty;
-import net.minecraft.world.level.block.state.properties.DirectionProperty;
-import net.minecraft.world.level.pathfinder.PathType;
-import net.minecraft.world.phys.BlockHitResult;
-import net.neoforged.neoforge.common.ItemAbilities;
-import vectorwing.farmersdelight.common.registry.ModDamageTypes;
+import vectorwing.farmersdelight.common.block.AbstractStoveBlock;
 import vectorwing.farmersdelight.common.registry.ModSounds;
-import vectorwing.farmersdelight.common.utility.ItemUtils;
-import vectorwing.farmersdelight.common.utility.MathUtils;
 
 import javax.annotation.Nullable;
-import java.util.Optional;
 
 @SuppressWarnings("deprecation")
-public class EndStoveBlock extends BaseEntityBlock
+public class EndStoveBlock extends AbstractStoveBlock
 {
     public static final MapCodec<EndStoveBlock> CODEC = simpleCodec(EndStoveBlock::new);
 
-    public static final BooleanProperty LIT = BlockStateProperties.LIT;
-    public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
-
-    public EndStoveBlock(BlockBehaviour.Properties properties) {
-        super(properties);
-        this.registerDefaultState(this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(LIT, false));
-    }
-
     @Override
-    protected MapCodec<? extends BaseEntityBlock> codec() {
+    public MapCodec<EndStoveBlock> codec() {
         return CODEC;
     }
 
-    @Override
-    protected ItemInteractionResult useItemOn(ItemStack heldStack, BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
-        Item heldItem = heldStack.getItem();
+    public EndStoveBlock(BlockBehaviour.Properties properties) {
+        super(properties);
+    }
 
-        if (state.getValue(LIT)) {
-            if (heldStack.canPerformAction(ItemAbilities.SHOVEL_DIG)) {
-                extinguish(state, level, pos);
-                heldStack.hurtAndBreak(1, player, LivingEntity.getSlotForHand(hand));
-                return ItemInteractionResult.SUCCESS;
-            } else if (heldItem == Items.WATER_BUCKET) {
-                if (!level.isClientSide()) {
-                    level.playSound(null, pos, SoundEvents.GENERIC_EXTINGUISH_FIRE, SoundSource.BLOCKS, 1.0F, 1.0F);
-                }
-                extinguish(state, level, pos);
-                if (!player.isCreative()) {
-                    player.setItemInHand(hand, new ItemStack(Items.BUCKET));
-                }
-                return ItemInteractionResult.SUCCESS;
-            }
-        } else {
-            if (heldItem instanceof FlintAndSteelItem) {
-                level.playSound(player, pos, SoundEvents.FLINTANDSTEEL_USE, SoundSource.BLOCKS, 1.0F, MathUtils.RAND.nextFloat() * 0.4F + 0.8F);
-                level.setBlock(pos, state.setValue(BlockStateProperties.LIT, Boolean.TRUE), 11);
-                heldStack.hurtAndBreak(1, player, LivingEntity.getSlotForHand(hand));
-                return ItemInteractionResult.SUCCESS;
-            } else if (heldItem instanceof FireChargeItem) {
-                level.playSound(null, pos, SoundEvents.FIRECHARGE_USE, SoundSource.BLOCKS, 1.0F, (MathUtils.RAND.nextFloat() - MathUtils.RAND.nextFloat()) * 0.2F + 1.0F);
-                level.setBlock(pos, state.setValue(BlockStateProperties.LIT, Boolean.TRUE), 11);
-                if (!player.isCreative()) {
-                    heldStack.shrink(1);
-                }
-                return ItemInteractionResult.SUCCESS;
-            }
-        }
+    public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
+        return new EndStoveBlockEntity(pos, state);
+    }
 
-        BlockEntity tileEntity = level.getBlockEntity(pos);
-        if (tileEntity instanceof EndStoveBlockEntity stoveEntity) {
-            int stoveSlot = stoveEntity.getNextEmptySlot();
-            if (stoveSlot < 0 || stoveEntity.isStoveBlockedAbove()) {
-                return ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
-            }
-            Optional<RecipeHolder<CampfireCookingRecipe>> recipe = stoveEntity.getMatchingRecipe(heldStack);
-            if (recipe.isPresent()) {
-                if (!level.isClientSide && stoveEntity.addItem(player.getAbilities().instabuild ? heldStack.copy() : heldStack, recipe.get(), stoveSlot)) {
-                    return ItemInteractionResult.SUCCESS;
-                }
-                return ItemInteractionResult.CONSUME;
-            }
-        }
-
-        return ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
+    @Nullable
+    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState state, BlockEntityType<T> blockEntityType) {
+        if (level.isClientSide && state.getValue(LIT)) return createTickerHelper(blockEntityType, ModBlockEntityTypes.END_STOVE.get(), EndStoveBlockEntity::particleTick);
+        return createStoveTicker(level, blockEntityType, ModBlockEntityTypes.END_STOVE.get());
     }
 
     @Override
-    public RenderShape getRenderShape(BlockState pState) {
-        return RenderShape.MODEL;
-    }
-
-    public void extinguish(BlockState state, Level level, BlockPos pos) {
-        level.setBlock(pos, state.setValue(LIT, false), 2);
+    public void animateTick(BlockState state, Level level, BlockPos pos, RandomSource random) {
+        if (!state.getValue(LIT)) return;
         double x = (double) pos.getX() + 0.5D;
         double y = pos.getY();
         double z = (double) pos.getZ() + 0.5D;
-        level.playLocalSound(x, y, z, SoundEvents.FIRE_EXTINGUISH, SoundSource.BLOCKS, 0.5F, 2.6F, false);
-    }
-
-    @Override
-    public BlockState getStateForPlacement(BlockPlaceContext context) {
-        return this.defaultBlockState().setValue(FACING, context.getHorizontalDirection().getOpposite()).setValue(LIT, true);
-    }
-
-    @Override
-    public void stepOn(Level level, BlockPos pos, BlockState state, Entity entity) {
-        boolean isLit = level.getBlockState(pos).getValue(EndStoveBlock.LIT);
-        if (isLit && !entity.isSteppingCarefully() && entity instanceof LivingEntity) {
-            entity.hurt(ModDamageTypes.getSimpleDamageSource(level, ModDamageTypes.STOVE_BURN), 1.0F);
+        if (random.nextInt(10) == 0) {
+            level.playLocalSound(x, y, z, ModSounds.BLOCK_STOVE_CRACKLE.get(), SoundSource.BLOCKS, 1.0F, 1.0F, false);
         }
 
-        super.stepOn(level, pos, state, entity);
-    }
-
-    @Override
-    public void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean isMoving) {
-        if (state.getBlock() != newState.getBlock()) {
-            BlockEntity tileEntity = level.getBlockEntity(pos);
-            if (tileEntity instanceof EndStoveBlockEntity) {
-                ItemUtils.dropItems(level, pos, ((EndStoveBlockEntity) tileEntity).getInventory());
-            }
-
-            super.onRemove(state, level, pos, newState, isMoving);
-        }
-    }
-
-    @Override
-    protected void createBlockStateDefinition(final StateDefinition.Builder<Block, BlockState> builder) {
-        super.createBlockStateDefinition(builder);
-        builder.add(LIT, FACING);
-    }
-
-    @Override
-    public void animateTick(BlockState stateIn, Level level, BlockPos pos, RandomSource rand) {
-        if (stateIn.getValue(CampfireBlock.LIT)) {
-            double x = (double) pos.getX() + 0.5D;
-            double y = pos.getY();
-            double z = (double) pos.getZ() + 0.5D;
-            if (rand.nextInt(10) == 0) {
-                level.playLocalSound(x, y, z, ModSounds.BLOCK_STOVE_CRACKLE.get(), SoundSource.BLOCKS, 1.0F, 1.0F, false);
-            }
-
-            Direction direction = stateIn.getValue(HorizontalDirectionalBlock.FACING);
-            Direction.Axis direction$axis = direction.getAxis();
-            double horizontalOffset = rand.nextDouble() * 0.6D - 0.3D;
-            double xOffset = direction$axis == Direction.Axis.X ? (double) direction.getStepX() * 0.52D : horizontalOffset;
-            double yOffset = rand.nextDouble() * 6.0D / 16.0D;
-            double zOffset = direction$axis == Direction.Axis.Z ? (double) direction.getStepZ() * 0.52D : horizontalOffset;
-            level.addParticle(ParticleTypes.SMOKE, x + xOffset, y + yOffset, z + zOffset, 0.0D, 0.0D, 0.0D);
-            level.addParticle(ParticleTypes.FLAME, x + xOffset, y + yOffset, z + zOffset, 0.0D, 0.0D, 0.0D);
-        }
-    }
-
-    @Nullable
-    @Override
-    public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
-        return ModBlockEntityTypes.END_STOVE.get().create(pos, state);
-    }
-
-    @Nullable
-    @Override
-    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState state, BlockEntityType<T> blockEntityType) {
-        if (state.getValue(LIT)) {
-            return createTickerHelper(blockEntityType, ModBlockEntityTypes.END_STOVE.get(), level.isClientSide
-                    ? EndStoveBlockEntity::animationTick
-                    : EndStoveBlockEntity::cookingTick);
-        }
-        return null;
-    }
-
-    @Nullable
-    @Override
-    public PathType getBlockPathType(BlockState state, BlockGetter world, BlockPos pos, @Nullable Mob entity) {
-        return state.getValue(LIT) ? PathType.DAMAGE_FIRE : null;
-    }
-
-    @Override
-    public BlockState rotate(BlockState pState, Rotation pRot) {
-        return pState.setValue(FACING, pRot.rotate(pState.getValue(FACING)));
-    }
-
-    @Override
-    public BlockState mirror(BlockState pState, Mirror pMirror) {
-        return pState.rotate(pMirror.getRotation(pState.getValue(FACING)));
+        Direction direction = state.getValue(HorizontalDirectionalBlock.FACING);
+        Direction.Axis direction$axis = direction.getAxis();
+        double horizontalOffset = random.nextDouble() * 0.6D - 0.3D;
+        double xOffset = direction$axis == Direction.Axis.X ? (double) direction.getStepX() * 0.52D : horizontalOffset;
+        double yOffset = random.nextDouble() * 6.0D / 16.0D;
+        double zOffset = direction$axis == Direction.Axis.Z ? (double) direction.getStepZ() * 0.52D : horizontalOffset;
+        level.addParticle(ParticleTypes.SMOKE, x + xOffset, y + yOffset, z + zOffset, 0.0D, 0.0D, 0.0D);
+        level.addParticle(ParticleTypes.FLAME, x + xOffset, y + yOffset, z + zOffset, 0.0D, 0.0D, 0.0D);
     }
 }

--- a/src/main/java/cn/foggyhillside/ends_delight/block/entity/EndStoveBlockEntity.java
+++ b/src/main/java/cn/foggyhillside/ends_delight/block/entity/EndStoveBlockEntity.java
@@ -1,233 +1,67 @@
 package cn.foggyhillside.ends_delight.block.entity;
 
-import com.google.common.collect.Lists;
-import com.plusls.EndsDelight.common.block.EndStoveBlock;
-import com.plusls.EndsDelight.common.capability.ItemHandlerHelper;
-import com.plusls.EndsDelight.common.registry.BlockEntityRegistry;
-import com.plusls.EndsDelight.common.registry.RecipeTypeRegistry;
-import com.plusls.EndsDelight.common.registry.SoundEventRegistry;
-import com.plusls.EndsDelight.common.util.ItemUtils;
+import cn.foggyhillside.ends_delight.registry.ModBlockEntityTypes;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.core.NonNullList;
 import net.minecraft.core.particles.ParticleTypes;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.sounds.SoundSource;
-import net.minecraft.util.Mth;
-import net.minecraft.world.ContainerHelper;
-import net.minecraft.world.WorldlyContainer;
-import net.minecraft.world.entity.item.ItemEntity;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.crafting.CampfireCookingRecipe;
-import net.minecraft.world.item.crafting.RecipeHolder;
-import net.minecraft.world.item.crafting.RecipeManager;
-import net.minecraft.world.item.crafting.SingleRecipeInput;
+import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.CampfireBlock;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import net.neoforged.neoforge.items.wrapper.SidedInvWrapper;
-import org.jetbrains.annotations.NotNull;
+import net.minecraft.world.phys.Vec2;
+import vectorwing.farmersdelight.common.block.AbstractStoveBlock;
+import vectorwing.farmersdelight.common.block.entity.AbstractStoveBlockEntity;
 
-import java.util.List;
-import java.util.Optional;
+public class EndStoveBlockEntity extends AbstractStoveBlockEntity {
 
-public class EndStoveBlockEntity extends BlockEntity implements WorldlyContainer {
-    private final NonNullList<ItemStack> inventory = NonNullList.withSize(4, ItemStack.EMPTY);
-    private final int[] cookingProgress = new int[4];
-    private final int[] cookingTime = new int[4];
-    private final RecipeManager.CachedCheck<SingleRecipeInput, CampfireCookingRecipe> quickCheck;
-
-    public EndStoveBlockEntity(BlockPos pos, BlockState blockState) {
-        super(BlockEntityRegistry.END_STOVE.get(), pos, blockState);
-        this.quickCheck = RecipeManager.createCheck(RecipeTypeRegistry.END_STOVE_COOKING.get());
-    }
-
-    public static void cookTick(Level level, BlockPos pos, BlockState state, EndStoveBlockEntity stove) {
-        boolean flag = false;
-
-        for (int i = 0; i < stove.inventory.size(); ++i) {
-            ItemStack itemstack = stove.inventory.get(i);
-            if (!itemstack.isEmpty()) {
-                flag = true;
-                ++stove.cookingProgress[i];
-
-                if (stove.cookingProgress[i] >= stove.cookingTime[i]) {
-                    SingleRecipeInput singleRecipeInput = new SingleRecipeInput(itemstack);
-                    ItemStack itemstack1 = level.getRecipeManager()
-                            .getRecipeFor(RecipeTypeRegistry.END_STOVE_COOKING.get(), singleRecipeInput, level)
-                            .map(recipe -> recipe.value().assemble(singleRecipeInput, level.registryAccess()))
-                            .orElse(itemstack);
-
-                    if (itemstack1.isItemEnabled(level.enabledFeatures())) {
-                        Containers.dropItemStack(level, pos.getX(), pos.getY(), pos.getZ(), itemstack1);
-                        stove.inventory.set(i, ItemStack.EMPTY);
-                        level.sendBlockUpdated(pos, state, state, 3);
-                        level.gameEvent(null, net.minecraft.world.level.gameevent.GameEvent.BLOCK_CHANGE, pos);
-                    }
-                }
-            }
-        }
-
-        if (flag) {
-            setChanged(level, pos, state);
-        }
-    }
-
-    public static void cooldownTick(Level level, BlockPos pos, BlockState state, EndStoveBlockEntity stove) {
-        boolean flag = false;
-
-        for (int i = 0; i < stove.inventory.size(); ++i) {
-            if (stove.cookingProgress[i] > 0) {
-                flag = true;
-                stove.cookingProgress[i] = Mth.clamp(stove.cookingProgress[i] - 2, 0, stove.cookingTime[i]);
-            }
-        }
-
-        if (flag) {
-            setChanged(level, pos, state);
-        }
+    public EndStoveBlockEntity(BlockPos pos, BlockState state) {
+        super(ModBlockEntityTypes.END_STOVE.get(), pos, state, RecipeType.CAMPFIRE_COOKING);
     }
 
     public static void particleTick(Level level, BlockPos pos, BlockState state, EndStoveBlockEntity stove) {
-        if (level.random.nextFloat() < 0.11F) {
-            for (int i = 0; i < level.random.nextInt(2) + 2; ++i) {
-                CampfireBlock.makeParticles(level, pos, state.getValue(EndStoveBlock.LIT), false);
+        if (stove.isEmpty()) return;
+        stove.addSmokeParticles();
+    }
+
+    public void addSmokeParticles() {
+        assert this.level != null;
+
+        var items = this.getItems();
+        for (int i = 0; i < items.getSlots(); ++i) {
+            if (items.getStackInSlot(i).isEmpty()) continue;
+            if (level.random.nextFloat() >= 0.2F) continue;
+            Vec2 itemOffset = this.getStoveItemOffset(i);
+            Direction direction = this.getBlockState().getValue(AbstractStoveBlock.FACING);
+            if (direction.get2DDataValue() % 2 != 0) {
+                itemOffset = new Vec2(itemOffset.y, itemOffset.x);
             }
-        }
 
-        int direction = state.getValue(EndStoveBlock.FACING).get2DDataValue();
+            double x = (worldPosition.getX() + 0.5D) - (direction.getStepX() * itemOffset.x) + (direction.getClockWise().getStepX() * itemOffset.x);
+            double y = worldPosition.getY() + 1.0D;
+            double z = (worldPosition.getZ() + 0.5D) - (direction.getStepZ() * itemOffset.y) + (direction.getClockWise().getStepZ() * itemOffset.y);
 
-        for (int j = 0; j < stove.inventory.size(); ++j) {
-            if (!stove.inventory.get(j).isEmpty() && level.random.nextFloat() < 0.2F) {
-                Direction direction1 = Direction.from2DDataValue(Math.floorMod(j + direction, 4));
-                float f = 0.3125F;
-                double d0 = pos.getX() + 0.5D - direction1.getStepX() * 0.3125D + direction1.getClockWise().getStepX() * 0.3125D;
-                double d1 = pos.getY() + 0.5D;
-                double d2 = pos.getZ() + 0.5D - direction1.getStepZ() * 0.3125D + direction1.getClockWise().getStepZ() * 0.3125D;
-
-                for (int k = 0; k < 4; ++k) {
-                    level.addParticle(
-                            ParticleTypes.SMOKE,
-                            d0,
-                            d1,
-                            d2,
-                            0.0D,
-                            5.0E-4D,
-                            0.0D
-                    );
-                }
+            for (int k = 0; k < 3; ++k) {
+                level.addParticle(ParticleTypes.SMOKE, x, y, z, 0.0D, 5.0E-4D, 0.0D);
             }
         }
     }
 
-    public NonNullList<ItemStack> getItems() {
-        return this.inventory;
+    @Override
+    protected int getInventorySlotCount() {
+        return 6;
     }
 
     @Override
-    public int[] getSlotsForFace(Direction side) {
-        return new int[]{0, 1, 2, 3};
-    }
-
-    @Override
-    public boolean canPlaceItemThroughFace(int index, ItemStack itemStack, Direction direction) {
-        return false;
-    }
-
-    @Override
-    public boolean canTakeItemThroughFace(int index, ItemStack stack, Direction direction) {
-        return true;
-    }
-
-    @Override
-    public int getContainerSize() {
-        return this.inventory.size();
-    }
-
-    @Override
-    public boolean isEmpty() {
-        return ItemUtils.doesInventoryHaveItems(this.inventory);
-    }
-
-    @Override
-    public ItemStack getItem(int slot) {
-        return this.inventory.get(slot);
-    }
-
-    @Override
-    public ItemStack removeItem(int slot, int amount) {
-        return ContainerHelper.removeItem(this.inventory, slot, amount);
-    }
-
-    @Override
-    public ItemStack removeItemNoUpdate(int slot) {
-        return ContainerHelper.takeItem(this.inventory, slot);
-    }
-
-    @Override
-    public void setItem(int slot, ItemStack stack) {
-        this.inventory.set(slot, stack);
-        stack.limitSize(this.getMaxStackSize());
-    }
-
-    @Override
-    public boolean stillValid(@NotNull net.minecraft.world.entity.player.Player player) {
-        return true;
-    }
-
-    @Override
-    public void clearContent() {
-        this.inventory.clear();
-    }
-
-    @Override
-    public void load(CompoundTag tag) {
-        super.load(tag);
-        ContainerHelper.loadAllItems(tag, this.inventory);
-
-        if (tag.contains("CookingTimes", 11)) {
-            int[] aint = tag.getIntArray("CookingTimes");
-            System.arraycopy(aint, 0, this.cookingTime, 0, Math.min(this.cookingTime.length, aint.length));
-        }
-
-        if (tag.contains("CookingProgress", 11)) {
-            int[] aint1 = tag.getIntArray("CookingProgress");
-            System.arraycopy(aint1, 0, this.cookingProgress, 0, Math.min(this.cookingProgress.length, aint1.length));
-        }
-    }
-
-    @Override
-    protected void saveAdditional(CompoundTag tag) {
-        super.saveAdditional(tag);
-        ContainerHelper.saveAllItems(tag, this.inventory, true);
-        tag.putIntArray("CookingProgress", this.cookingProgress);
-        tag.putIntArray("CookingTimes", this.cookingTime);
-    }
-
-    public Optional<RecipeHolder<CampfireCookingRecipe>> getCookableRecipe(ItemStack stack) {
-        return this.quickCheck.getRecipeFor(new SingleRecipeInput(stack), this.level);
-    }
-
-    public boolean placeFood(@NotNull ItemStack stack, int cookingTimeIn) {
-        for (int i = 0; i < this.inventory.size(); ++i) {
-            ItemStack itemstack = this.inventory.get(i);
-
-            if (itemstack.isEmpty()) {
-                this.cookingTime[i] = cookingTimeIn;
-                this.cookingProgress[i] = 0;
-                this.inventory.set(i, stack.split(1));
-                this.level.gameEvent(net.minecraft.world.level.gameevent.GameEvent.BLOCK_CHANGE, this.getBlockPos(), net.minecraft.world.level.gameevent.GameEvent.Context.of(this.getBlockState()));
-                this.markUpdated();
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private void markUpdated() {
-        this.setChanged();
-        this.getLevel().sendBlockUpdated(this.getBlockPos(), this.getBlockState(), this.getBlockState(), 3);
+    public Vec2 getStoveItemOffset(int index) {
+        final float X_OFFSET = 0.3F;
+        final float Y_OFFSET = 0.2F;
+        final Vec2[] OFFSETS = {
+                new Vec2(X_OFFSET, Y_OFFSET),
+                new Vec2(0.0F, Y_OFFSET),
+                new Vec2(-X_OFFSET, Y_OFFSET),
+                new Vec2(X_OFFSET, -Y_OFFSET),
+                new Vec2(0.0F, -Y_OFFSET),
+                new Vec2(-X_OFFSET, -Y_OFFSET),
+        };
+        return OFFSETS[index];
     }
 }

--- a/src/main/java/cn/foggyhillside/ends_delight/block/entity/EndStoveBlockEntity.java
+++ b/src/main/java/cn/foggyhillside/ends_delight/block/entity/EndStoveBlockEntity.java
@@ -1,4 +1,4 @@
-package com.plusls.EndsDelight.common.block.entity;
+package cn.foggyhillside.ends_delight.block.entity;
 
 import com.google.common.collect.Lists;
 import com.plusls.EndsDelight.common.block.EndStoveBlock;

--- a/src/main/java/cn/foggyhillside/ends_delight/block/entity/EndStoveBlockEntity.java
+++ b/src/main/java/cn/foggyhillside/ends_delight/block/entity/EndStoveBlockEntity.java
@@ -50,14 +50,17 @@ public class EndStoveBlockEntity extends SyncedBlockEntity {
         } else {
             inventory.deserializeNBT(registries, tag);
         }
+
         if (tag.contains("CookingTimes", 11)) {
             int[] arrayCookingTimes = tag.getIntArray("CookingTimes");
-            System.arraycopy(arrayCookingTimes, 0, cookingTimes, 0, Math.min(cookingTimesTotal.length, arrayCookingTimes.length));
+            System.arraycopy(arrayCookingTimes, 0, cookingTimes, 0,
+                    Math.min(cookingTimesTotal.length, arrayCookingTimes.length));
         }
 
         if (tag.contains("CookingTotalTimes", 11)) {
             int[] arrayCookingTimesTotal = tag.getIntArray("CookingTotalTimes");
-            System.arraycopy(arrayCookingTimesTotal, 0, cookingTimesTotal, 0, Math.min(cookingTimesTotal.length, arrayCookingTimesTotal.length));
+            System.arraycopy(arrayCookingTimesTotal, 0, cookingTimesTotal, 0,
+                    Math.min(cookingTimesTotal.length, arrayCookingTimesTotal.length));
         }
     }
 
@@ -78,16 +81,26 @@ public class EndStoveBlockEntity extends SyncedBlockEntity {
         boolean isStoveLit = state.getValue(StoveBlock.LIT);
 
         if (stove.isStoveBlockedAbove()) {
-            if (!ItemUtils.isInventoryEmpty(stove.inventory)) {
+
+            // Farmer's Delight 1.3.x compatibility fix
+            // isInventoryEmpty(IItemHandler) was removed and replaced by
+            // doesInventoryHaveItems(IItemHandler)
+
+            if (ItemUtils.doesInventoryHaveItems(stove.inventory)) {
                 ItemUtils.dropItems(level, pos, stove.inventory);
                 stove.inventoryChanged();
             }
+
         } else if (isStoveLit) {
+
             stove.cookAndOutputItems();
+
         } else {
+
             for (int i = 0; i < stove.inventory.getSlots(); ++i) {
                 if (stove.cookingTimes[i] > 0) {
-                    stove.cookingTimes[i] = Mth.clamp(stove.cookingTimes[i] - 2, 0, stove.cookingTimesTotal[i]);
+                    stove.cookingTimes[i] =
+                            Mth.clamp(stove.cookingTimes[i] - 2, 0, stove.cookingTimesTotal[i]);
                 }
             }
         }
@@ -96,17 +109,38 @@ public class EndStoveBlockEntity extends SyncedBlockEntity {
     public static void animationTick(Level level, BlockPos pos, BlockState state, EndStoveBlockEntity stove) {
         for (int i = 0; i < stove.inventory.getSlots(); ++i) {
             if (!stove.inventory.getStackInSlot(i).isEmpty() && level.random.nextFloat() < 0.2F) {
+
                 Vec2 stoveItemVector = stove.getStoveItemOffset(i);
                 Direction direction = state.getValue(StoveBlock.FACING);
                 int directionIndex = direction.get2DDataValue();
-                Vec2 offset = directionIndex % 2 == 0 ? stoveItemVector : new Vec2(stoveItemVector.y, stoveItemVector.x);
 
-                double x = ((double) pos.getX() + 0.5D) - (direction.getStepX() * offset.x) + (direction.getClockWise().getStepX() * offset.x);
+                Vec2 offset =
+                        directionIndex % 2 == 0
+                                ? stoveItemVector
+                                : new Vec2(stoveItemVector.y, stoveItemVector.x);
+
+                double x =
+                        ((double) pos.getX() + 0.5D)
+                                - (direction.getStepX() * offset.x)
+                                + (direction.getClockWise().getStepX() * offset.x);
+
                 double y = (double) pos.getY() + 1.0D;
-                double z = ((double) pos.getZ() + 0.5D) - (direction.getStepZ() * offset.y) + (direction.getClockWise().getStepZ() * offset.y);
+
+                double z =
+                        ((double) pos.getZ() + 0.5D)
+                                - (direction.getStepZ() * offset.y)
+                                + (direction.getClockWise().getStepZ() * offset.y);
 
                 for (int k = 0; k < 3; ++k) {
-                    level.addParticle(ParticleTypes.SMOKE, x, y, z, 0.0D, 5.0E-4D, 0.0D);
+                    level.addParticle(
+                            ParticleTypes.SMOKE,
+                            x,
+                            y,
+                            z,
+                            0.0D,
+                            5.0E-4D,
+                            0.0D
+                    );
                 }
             }
         }
@@ -116,20 +150,40 @@ public class EndStoveBlockEntity extends SyncedBlockEntity {
         if (level == null) return;
 
         boolean didInventoryChange = false;
+
         for (int i = 0; i < inventory.getSlots(); ++i) {
+
             ItemStack stoveStack = inventory.getStackInSlot(i);
+
             if (!stoveStack.isEmpty()) {
+
                 ++cookingTimes[i];
+
                 if (cookingTimes[i] >= cookingTimesTotal[i]) {
-                    Optional<RecipeHolder<CampfireCookingRecipe>> recipe = getMatchingRecipe(stoveStack);
+
+                    Optional<RecipeHolder<CampfireCookingRecipe>> recipe =
+                            getMatchingRecipe(stoveStack);
+
                     if (recipe.isPresent()) {
-                        ItemStack resultStack = recipe.get().value().getResultItem(level.registryAccess());
+
+                        ItemStack resultStack =
+                                recipe.get().value().getResultItem(level.registryAccess());
+
                         if (!resultStack.isEmpty()) {
-                            ItemUtils.spawnItemEntity(level, resultStack.copy(),
-                                    worldPosition.getX() + 0.5, worldPosition.getY() + 1.0, worldPosition.getZ() + 0.5,
-                                    level.random.nextGaussian() * (double) 0.01F, 0.1F, level.random.nextGaussian() * (double) 0.01F);
+
+                            ItemUtils.spawnItemEntity(
+                                    level,
+                                    resultStack.copy(),
+                                    worldPosition.getX() + 0.5,
+                                    worldPosition.getY() + 1.0,
+                                    worldPosition.getZ() + 0.5,
+                                    level.random.nextGaussian() * (double) 0.01F,
+                                    0.1F,
+                                    level.random.nextGaussian() * (double) 0.01F
+                            );
                         }
                     }
+
                     inventory.setStackInSlot(i, ItemStack.EMPTY);
                     didInventoryChange = true;
                 }
@@ -144,30 +198,46 @@ public class EndStoveBlockEntity extends SyncedBlockEntity {
     public int getNextEmptySlot() {
         for (int i = 0; i < inventory.getSlots(); ++i) {
             ItemStack slotStack = inventory.getStackInSlot(i);
+
             if (slotStack.isEmpty()) {
                 return i;
             }
         }
+
         return -1;
     }
 
-    public boolean addItem(ItemStack itemStackIn, RecipeHolder<CampfireCookingRecipe> recipe, int slot) {
+    public boolean addItem(ItemStack itemStackIn,
+                           RecipeHolder<CampfireCookingRecipe> recipe,
+                           int slot) {
+
         if (0 <= slot && slot < inventory.getSlots()) {
+
             ItemStack slotStack = inventory.getStackInSlot(slot);
+
             if (slotStack.isEmpty()) {
+
                 cookingTimesTotal[slot] = recipe.value().getCookingTime();
                 cookingTimes[slot] = 0;
+
                 inventory.setStackInSlot(slot, itemStackIn.split(1));
+
                 inventoryChanged();
+
                 return true;
             }
         }
+
         return false;
     }
 
     public Optional<RecipeHolder<CampfireCookingRecipe>> getMatchingRecipe(ItemStack stack) {
         if (level == null) return Optional.empty();
-        return this.quickCheck.getRecipeFor(new SingleRecipeInput(stack), this.level);
+
+        return this.quickCheck.getRecipeFor(
+                new SingleRecipeInput(stack),
+                this.level
+        );
     }
 
     public ItemStackHandler getInventory() {
@@ -176,15 +246,24 @@ public class EndStoveBlockEntity extends SyncedBlockEntity {
 
     public boolean isStoveBlockedAbove() {
         if (level != null) {
+
             BlockState above = level.getBlockState(worldPosition.above());
-            return Shapes.joinIsNotEmpty(GRILLING_AREA, above.getShape(level, worldPosition.above()), BooleanOp.AND);
+
+            return Shapes.joinIsNotEmpty(
+                    GRILLING_AREA,
+                    above.getShape(level, worldPosition.above()),
+                    BooleanOp.AND
+            );
         }
+
         return false;
     }
 
     public Vec2 getStoveItemOffset(int index) {
+
         final float X_OFFSET = 0.3F;
         final float Y_OFFSET = 0.2F;
+
         final Vec2[] OFFSETS = {
                 new Vec2(X_OFFSET, Y_OFFSET),
                 new Vec2(0.0F, Y_OFFSET),
@@ -193,6 +272,7 @@ public class EndStoveBlockEntity extends SyncedBlockEntity {
                 new Vec2(0.0F, -Y_OFFSET),
                 new Vec2(-X_OFFSET, -Y_OFFSET),
         };
+
         return OFFSETS[index];
     }
 
@@ -202,8 +282,9 @@ public class EndStoveBlockEntity extends SyncedBlockEntity {
     }
 
     private ItemStackHandler createHandler() {
-        return new ItemStackHandler(INVENTORY_SLOT_COUNT)
-        {
+
+        return new ItemStackHandler(INVENTORY_SLOT_COUNT) {
+
             @Override
             public int getSlotLimit(int slot) {
                 return 1;

--- a/src/main/java/cn/foggyhillside/ends_delight/block/entity/EndStoveBlockEntity.java
+++ b/src/main/java/cn/foggyhillside/ends_delight/block/entity/EndStoveBlockEntity.java
@@ -1,142 +1,117 @@
-package cn.foggyhillside.ends_delight.block.entity;
+package com.plusls.EndsDelight.common.block.entity;
 
-import cn.foggyhillside.ends_delight.registry.ModBlockEntityTypes;
+import com.google.common.collect.Lists;
+import com.plusls.EndsDelight.common.block.EndStoveBlock;
+import com.plusls.EndsDelight.common.capability.ItemHandlerHelper;
+import com.plusls.EndsDelight.common.registry.BlockEntityRegistry;
+import com.plusls.EndsDelight.common.registry.RecipeTypeRegistry;
+import com.plusls.EndsDelight.common.registry.SoundEventRegistry;
+import com.plusls.EndsDelight.common.util.ItemUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.core.HolderLookup;
+import net.minecraft.core.NonNullList;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.Mth;
+import net.minecraft.world.ContainerHelper;
+import net.minecraft.world.WorldlyContainer;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.crafting.*;
+import net.minecraft.world.item.crafting.CampfireCookingRecipe;
+import net.minecraft.world.item.crafting.RecipeHolder;
+import net.minecraft.world.item.crafting.RecipeManager;
+import net.minecraft.world.item.crafting.SingleRecipeInput;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.CampfireBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.phys.Vec2;
-import net.minecraft.world.phys.shapes.BooleanOp;
-import net.minecraft.world.phys.shapes.Shapes;
-import net.minecraft.world.phys.shapes.VoxelShape;
-import net.neoforged.neoforge.items.ItemStackHandler;
-import vectorwing.farmersdelight.common.block.StoveBlock;
-import vectorwing.farmersdelight.common.block.entity.SyncedBlockEntity;
-import vectorwing.farmersdelight.common.utility.ItemUtils;
+import net.neoforged.neoforge.items.wrapper.SidedInvWrapper;
+import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
 import java.util.Optional;
 
-public class EndStoveBlockEntity extends SyncedBlockEntity {
-
-    private static final VoxelShape GRILLING_AREA = Block.box(3.0F, 0.0F, 3.0F, 13.0F, 1.0F, 13.0F);
-    private static final int INVENTORY_SLOT_COUNT = 6;
-
-    private final ItemStackHandler inventory;
-    private final int[] cookingTimes;
-    private final int[] cookingTimesTotal;
-
+public class EndStoveBlockEntity extends BlockEntity implements WorldlyContainer {
+    private final NonNullList<ItemStack> inventory = NonNullList.withSize(4, ItemStack.EMPTY);
+    private final int[] cookingProgress = new int[4];
+    private final int[] cookingTime = new int[4];
     private final RecipeManager.CachedCheck<SingleRecipeInput, CampfireCookingRecipe> quickCheck;
 
-    public EndStoveBlockEntity(BlockPos pos, BlockState state) {
-        super(ModBlockEntityTypes.END_STOVE.get(), pos, state);
-        inventory = createHandler();
-        cookingTimes = new int[INVENTORY_SLOT_COUNT];
-        cookingTimesTotal = new int[INVENTORY_SLOT_COUNT];
-        quickCheck = RecipeManager.createCheck(RecipeType.CAMPFIRE_COOKING);
+    public EndStoveBlockEntity(BlockPos pos, BlockState blockState) {
+        super(BlockEntityRegistry.END_STOVE.get(), pos, blockState);
+        this.quickCheck = RecipeManager.createCheck(RecipeTypeRegistry.END_STOVE_COOKING.get());
     }
 
-    @Override
-    public void loadAdditional(CompoundTag tag, HolderLookup.Provider registries) {
-        super.loadAdditional(tag, registries);
-        if (tag.contains("Inventory")) {
-            inventory.deserializeNBT(registries, tag.getCompound("Inventory"));
-        } else {
-            inventory.deserializeNBT(registries, tag);
-        }
+    public static void cookTick(Level level, BlockPos pos, BlockState state, EndStoveBlockEntity stove) {
+        boolean flag = false;
 
-        if (tag.contains("CookingTimes", 11)) {
-            int[] arrayCookingTimes = tag.getIntArray("CookingTimes");
-            System.arraycopy(arrayCookingTimes, 0, cookingTimes, 0,
-                    Math.min(cookingTimesTotal.length, arrayCookingTimes.length));
-        }
+        for (int i = 0; i < stove.inventory.size(); ++i) {
+            ItemStack itemstack = stove.inventory.get(i);
+            if (!itemstack.isEmpty()) {
+                flag = true;
+                ++stove.cookingProgress[i];
 
-        if (tag.contains("CookingTotalTimes", 11)) {
-            int[] arrayCookingTimesTotal = tag.getIntArray("CookingTotalTimes");
-            System.arraycopy(arrayCookingTimesTotal, 0, cookingTimesTotal, 0,
-                    Math.min(cookingTimesTotal.length, arrayCookingTimesTotal.length));
-        }
-    }
+                if (stove.cookingProgress[i] >= stove.cookingTime[i]) {
+                    SingleRecipeInput singleRecipeInput = new SingleRecipeInput(itemstack);
+                    ItemStack itemstack1 = level.getRecipeManager()
+                            .getRecipeFor(RecipeTypeRegistry.END_STOVE_COOKING.get(), singleRecipeInput, level)
+                            .map(recipe -> recipe.value().assemble(singleRecipeInput, level.registryAccess()))
+                            .orElse(itemstack);
 
-    @Override
-    public void saveAdditional(CompoundTag compound, HolderLookup.Provider registries) {
-        writeItems(compound, registries);
-        compound.putIntArray("CookingTimes", cookingTimes);
-        compound.putIntArray("CookingTotalTimes", cookingTimesTotal);
-    }
-
-    private CompoundTag writeItems(CompoundTag compound, HolderLookup.Provider registries) {
-        super.saveAdditional(compound, registries);
-        compound.put("Inventory", inventory.serializeNBT(registries));
-        return compound;
-    }
-
-    public static void cookingTick(Level level, BlockPos pos, BlockState state, EndStoveBlockEntity stove) {
-        boolean isStoveLit = state.getValue(StoveBlock.LIT);
-
-        if (stove.isStoveBlockedAbove()) {
-
-            // Farmer's Delight 1.3.x compatibility fix
-            // isInventoryEmpty(IItemHandler) was removed and replaced by
-            // doesInventoryHaveItems(IItemHandler)
-
-            if (ItemUtils.doesInventoryHaveItems(stove.inventory)) {
-                ItemUtils.dropItems(level, pos, stove.inventory);
-                stove.inventoryChanged();
-            }
-
-        } else if (isStoveLit) {
-
-            stove.cookAndOutputItems();
-
-        } else {
-
-            for (int i = 0; i < stove.inventory.getSlots(); ++i) {
-                if (stove.cookingTimes[i] > 0) {
-                    stove.cookingTimes[i] =
-                            Mth.clamp(stove.cookingTimes[i] - 2, 0, stove.cookingTimesTotal[i]);
+                    if (itemstack1.isItemEnabled(level.enabledFeatures())) {
+                        Containers.dropItemStack(level, pos.getX(), pos.getY(), pos.getZ(), itemstack1);
+                        stove.inventory.set(i, ItemStack.EMPTY);
+                        level.sendBlockUpdated(pos, state, state, 3);
+                        level.gameEvent(null, net.minecraft.world.level.gameevent.GameEvent.BLOCK_CHANGE, pos);
+                    }
                 }
             }
         }
+
+        if (flag) {
+            setChanged(level, pos, state);
+        }
     }
 
-    public static void animationTick(Level level, BlockPos pos, BlockState state, EndStoveBlockEntity stove) {
-        for (int i = 0; i < stove.inventory.getSlots(); ++i) {
-            if (!stove.inventory.getStackInSlot(i).isEmpty() && level.random.nextFloat() < 0.2F) {
+    public static void cooldownTick(Level level, BlockPos pos, BlockState state, EndStoveBlockEntity stove) {
+        boolean flag = false;
 
-                Vec2 stoveItemVector = stove.getStoveItemOffset(i);
-                Direction direction = state.getValue(StoveBlock.FACING);
-                int directionIndex = direction.get2DDataValue();
+        for (int i = 0; i < stove.inventory.size(); ++i) {
+            if (stove.cookingProgress[i] > 0) {
+                flag = true;
+                stove.cookingProgress[i] = Mth.clamp(stove.cookingProgress[i] - 2, 0, stove.cookingTime[i]);
+            }
+        }
 
-                Vec2 offset =
-                        directionIndex % 2 == 0
-                                ? stoveItemVector
-                                : new Vec2(stoveItemVector.y, stoveItemVector.x);
+        if (flag) {
+            setChanged(level, pos, state);
+        }
+    }
 
-                double x =
-                        ((double) pos.getX() + 0.5D)
-                                - (direction.getStepX() * offset.x)
-                                + (direction.getClockWise().getStepX() * offset.x);
+    public static void particleTick(Level level, BlockPos pos, BlockState state, EndStoveBlockEntity stove) {
+        if (level.random.nextFloat() < 0.11F) {
+            for (int i = 0; i < level.random.nextInt(2) + 2; ++i) {
+                CampfireBlock.makeParticles(level, pos, state.getValue(EndStoveBlock.LIT), false);
+            }
+        }
 
-                double y = (double) pos.getY() + 1.0D;
+        int direction = state.getValue(EndStoveBlock.FACING).get2DDataValue();
 
-                double z =
-                        ((double) pos.getZ() + 0.5D)
-                                - (direction.getStepZ() * offset.y)
-                                + (direction.getClockWise().getStepZ() * offset.y);
+        for (int j = 0; j < stove.inventory.size(); ++j) {
+            if (!stove.inventory.get(j).isEmpty() && level.random.nextFloat() < 0.2F) {
+                Direction direction1 = Direction.from2DDataValue(Math.floorMod(j + direction, 4));
+                float f = 0.3125F;
+                double d0 = pos.getX() + 0.5D - direction1.getStepX() * 0.3125D + direction1.getClockWise().getStepX() * 0.3125D;
+                double d1 = pos.getY() + 0.5D;
+                double d2 = pos.getZ() + 0.5D - direction1.getStepZ() * 0.3125D + direction1.getClockWise().getStepZ() * 0.3125D;
 
-                for (int k = 0; k < 3; ++k) {
+                for (int k = 0; k < 4; ++k) {
                     level.addParticle(
                             ParticleTypes.SMOKE,
-                            x,
-                            y,
-                            z,
+                            d0,
+                            d1,
+                            d2,
                             0.0D,
                             5.0E-4D,
                             0.0D
@@ -146,84 +121,104 @@ public class EndStoveBlockEntity extends SyncedBlockEntity {
         }
     }
 
-    private void cookAndOutputItems() {
-        if (level == null) return;
+    public NonNullList<ItemStack> getItems() {
+        return this.inventory;
+    }
 
-        boolean didInventoryChange = false;
+    @Override
+    public int[] getSlotsForFace(Direction side) {
+        return new int[]{0, 1, 2, 3};
+    }
 
-        for (int i = 0; i < inventory.getSlots(); ++i) {
+    @Override
+    public boolean canPlaceItemThroughFace(int index, ItemStack itemStack, Direction direction) {
+        return false;
+    }
 
-            ItemStack stoveStack = inventory.getStackInSlot(i);
+    @Override
+    public boolean canTakeItemThroughFace(int index, ItemStack stack, Direction direction) {
+        return true;
+    }
 
-            if (!stoveStack.isEmpty()) {
+    @Override
+    public int getContainerSize() {
+        return this.inventory.size();
+    }
 
-                ++cookingTimes[i];
+    @Override
+    public boolean isEmpty() {
+        return ItemUtils.doesInventoryHaveItems(this.inventory);
+    }
 
-                if (cookingTimes[i] >= cookingTimesTotal[i]) {
+    @Override
+    public ItemStack getItem(int slot) {
+        return this.inventory.get(slot);
+    }
 
-                    Optional<RecipeHolder<CampfireCookingRecipe>> recipe =
-                            getMatchingRecipe(stoveStack);
+    @Override
+    public ItemStack removeItem(int slot, int amount) {
+        return ContainerHelper.removeItem(this.inventory, slot, amount);
+    }
 
-                    if (recipe.isPresent()) {
+    @Override
+    public ItemStack removeItemNoUpdate(int slot) {
+        return ContainerHelper.takeItem(this.inventory, slot);
+    }
 
-                        ItemStack resultStack =
-                                recipe.get().value().getResultItem(level.registryAccess());
+    @Override
+    public void setItem(int slot, ItemStack stack) {
+        this.inventory.set(slot, stack);
+        stack.limitSize(this.getMaxStackSize());
+    }
 
-                        if (!resultStack.isEmpty()) {
+    @Override
+    public boolean stillValid(@NotNull net.minecraft.world.entity.player.Player player) {
+        return true;
+    }
 
-                            ItemUtils.spawnItemEntity(
-                                    level,
-                                    resultStack.copy(),
-                                    worldPosition.getX() + 0.5,
-                                    worldPosition.getY() + 1.0,
-                                    worldPosition.getZ() + 0.5,
-                                    level.random.nextGaussian() * (double) 0.01F,
-                                    0.1F,
-                                    level.random.nextGaussian() * (double) 0.01F
-                            );
-                        }
-                    }
+    @Override
+    public void clearContent() {
+        this.inventory.clear();
+    }
 
-                    inventory.setStackInSlot(i, ItemStack.EMPTY);
-                    didInventoryChange = true;
-                }
-            }
+    @Override
+    public void load(CompoundTag tag) {
+        super.load(tag);
+        ContainerHelper.loadAllItems(tag, this.inventory);
+
+        if (tag.contains("CookingTimes", 11)) {
+            int[] aint = tag.getIntArray("CookingTimes");
+            System.arraycopy(aint, 0, this.cookingTime, 0, Math.min(this.cookingTime.length, aint.length));
         }
 
-        if (didInventoryChange) {
-            inventoryChanged();
+        if (tag.contains("CookingProgress", 11)) {
+            int[] aint1 = tag.getIntArray("CookingProgress");
+            System.arraycopy(aint1, 0, this.cookingProgress, 0, Math.min(this.cookingProgress.length, aint1.length));
         }
     }
 
-    public int getNextEmptySlot() {
-        for (int i = 0; i < inventory.getSlots(); ++i) {
-            ItemStack slotStack = inventory.getStackInSlot(i);
-
-            if (slotStack.isEmpty()) {
-                return i;
-            }
-        }
-
-        return -1;
+    @Override
+    protected void saveAdditional(CompoundTag tag) {
+        super.saveAdditional(tag);
+        ContainerHelper.saveAllItems(tag, this.inventory, true);
+        tag.putIntArray("CookingProgress", this.cookingProgress);
+        tag.putIntArray("CookingTimes", this.cookingTime);
     }
 
-    public boolean addItem(ItemStack itemStackIn,
-                           RecipeHolder<CampfireCookingRecipe> recipe,
-                           int slot) {
+    public Optional<RecipeHolder<CampfireCookingRecipe>> getCookableRecipe(ItemStack stack) {
+        return this.quickCheck.getRecipeFor(new SingleRecipeInput(stack), this.level);
+    }
 
-        if (0 <= slot && slot < inventory.getSlots()) {
+    public boolean placeFood(@NotNull ItemStack stack, int cookingTimeIn) {
+        for (int i = 0; i < this.inventory.size(); ++i) {
+            ItemStack itemstack = this.inventory.get(i);
 
-            ItemStack slotStack = inventory.getStackInSlot(slot);
-
-            if (slotStack.isEmpty()) {
-
-                cookingTimesTotal[slot] = recipe.value().getCookingTime();
-                cookingTimes[slot] = 0;
-
-                inventory.setStackInSlot(slot, itemStackIn.split(1));
-
-                inventoryChanged();
-
+            if (itemstack.isEmpty()) {
+                this.cookingTime[i] = cookingTimeIn;
+                this.cookingProgress[i] = 0;
+                this.inventory.set(i, stack.split(1));
+                this.level.gameEvent(net.minecraft.world.level.gameevent.GameEvent.BLOCK_CHANGE, this.getBlockPos(), net.minecraft.world.level.gameevent.GameEvent.Context.of(this.getBlockState()));
+                this.markUpdated();
                 return true;
             }
         }
@@ -231,64 +226,8 @@ public class EndStoveBlockEntity extends SyncedBlockEntity {
         return false;
     }
 
-    public Optional<RecipeHolder<CampfireCookingRecipe>> getMatchingRecipe(ItemStack stack) {
-        if (level == null) return Optional.empty();
-
-        return this.quickCheck.getRecipeFor(
-                new SingleRecipeInput(stack),
-                this.level
-        );
-    }
-
-    public ItemStackHandler getInventory() {
-        return this.inventory;
-    }
-
-    public boolean isStoveBlockedAbove() {
-        if (level != null) {
-
-            BlockState above = level.getBlockState(worldPosition.above());
-
-            return Shapes.joinIsNotEmpty(
-                    GRILLING_AREA,
-                    above.getShape(level, worldPosition.above()),
-                    BooleanOp.AND
-            );
-        }
-
-        return false;
-    }
-
-    public Vec2 getStoveItemOffset(int index) {
-
-        final float X_OFFSET = 0.3F;
-        final float Y_OFFSET = 0.2F;
-
-        final Vec2[] OFFSETS = {
-                new Vec2(X_OFFSET, Y_OFFSET),
-                new Vec2(0.0F, Y_OFFSET),
-                new Vec2(-X_OFFSET, Y_OFFSET),
-                new Vec2(X_OFFSET, -Y_OFFSET),
-                new Vec2(0.0F, -Y_OFFSET),
-                new Vec2(-X_OFFSET, -Y_OFFSET),
-        };
-
-        return OFFSETS[index];
-    }
-
-    @Override
-    public CompoundTag getUpdateTag(HolderLookup.Provider registries) {
-        return writeItems(new CompoundTag(), registries);
-    }
-
-    private ItemStackHandler createHandler() {
-
-        return new ItemStackHandler(INVENTORY_SLOT_COUNT) {
-
-            @Override
-            public int getSlotLimit(int slot) {
-                return 1;
-            }
-        };
+    private void markUpdated() {
+        this.setChanged();
+        this.getLevel().sendBlockUpdated(this.getBlockPos(), this.getBlockState(), this.getBlockState(), 3);
     }
 }

--- a/src/main/java/cn/foggyhillside/ends_delight/client/renderer/EndStoveRenderer.java
+++ b/src/main/java/cn/foggyhillside/ends_delight/client/renderer/EndStoveRenderer.java
@@ -24,7 +24,7 @@ public class EndStoveRenderer implements BlockEntityRenderer<EndStoveBlockEntity
     public void render(EndStoveBlockEntity stoveEntity, float partialTicks, PoseStack poseStack, MultiBufferSource buffer, int combinedLightIn, int combinedOverlayIn) {
         Direction direction = stoveEntity.getBlockState().getValue(EndStoveBlock.FACING).getOpposite();
 
-        ItemStackHandler inventory = stoveEntity.getInventory();
+        ItemStackHandler inventory = stoveEntity.getItems();
         int posLong = (int) stoveEntity.getBlockPos().asLong();
 
         for (int i = 0; i < inventory.getSlots(); ++i) {

--- a/src/main/resources/data/ends_delight/recipe/food/bubble_tea.json
+++ b/src/main/resources/data/ends_delight/recipe/food/bubble_tea.json
@@ -2,7 +2,7 @@
   "type": "farmersdelight:cooking",
   "ingredients": [
     {
-      "tag": "c:foods/milk"
+      "tag": "c:drinks/milk"
     },
     {
       "type": "neoforge:compound",

--- a/src/main/resources/data/ends_delight/recipe/food/chorus_fruit_milk_tea.json
+++ b/src/main/resources/data/ends_delight/recipe/food/chorus_fruit_milk_tea.json
@@ -2,7 +2,7 @@
   "type": "farmersdelight:cooking",
   "ingredients": [
     {
-      "tag": "c:foods/milk"
+      "tag": "c:drinks/milk"
     },
     {
       "type": "neoforge:compound",


### PR DESCRIPTION
Built on top of the original Farmer’s Delight compatibility/API migration work from PR #60:
https://github.com/FoggyHillside/End-s-Delight/pull/60

While validating the PR against the current Farmer’s Delight 1.3.0+ API, an additional crash path was identified and fixed.

The remaining issue was inside `EndStoveBlockEntity`, where outdated stove/cookware interaction handling could still cause dedicated server crashes when blocks were placed above the End Stove.

Additional fixes included:

* updated remaining stove interaction calls to match current Farmer’s Delight behavior
* corrected remaining compatibility handling inside `EndStoveBlockEntity`
* verified stove, cookware, and block-above interactions against current Farmer’s Delight behavior
* tested mixed patched/unpatched environments to confirm compatibility behavior
* updated the milk tags from foods to drinks in the .json

Primary affected file:

* `EndStoveBlockEntity.java`

Validated on:

* Minecraft 1.21.1
* NeoForge 21.1.222
* Farmer’s Delight 1.3.0+

Tested dedicated server and live gameplay scenarios with placed stoves/cookware to confirm the remaining crash path was resolved.
