### PR TITLE
[1.20.1-Forge] Fix NoSuchMethodError for ItemUtils.isInventoryEmpty with Farmer's Delight 1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ repositories {
 dependencies {
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
 
-    implementation fg.deobf("curse.maven:farmersdelight-398521:5051242")
+    implementation fg.deobf("curse.maven:farmersdelight-398521:8007609")
 }
 
 tasks.named('processResources', ProcessResources).configure {

--- a/src/main/java/cn/foggyhillside/ends_delight/blockentitiy/EndStoveBlockEntity.java
+++ b/src/main/java/cn/foggyhillside/ends_delight/blockentitiy/EndStoveBlockEntity.java
@@ -77,7 +77,7 @@ public class EndStoveBlockEntity extends SyncedBlockEntity {
     public static void cookingTick(Level level, BlockPos pos, BlockState state, EndStoveBlockEntity stove) {
         boolean isStoveLit = (Boolean)state.getValue(EndStoveBlock.LIT);
         if (stove.isStoveBlockedAbove()) {
-            if (!isInventoryEmpty(stove.inventory)) {
+            if (ItemUtils.doesInventoryHaveItems(stove.inventory)) {
                 ItemUtils.dropItems(level, pos, stove.inventory);
                 stove.inventoryChanged();
             }
@@ -236,14 +236,5 @@ public class EndStoveBlockEntity extends SyncedBlockEntity {
                 return 1;
             }
         };
-    }
-
-    private static boolean isInventoryEmpty(ItemStackHandler handler) {
-        for (int i = 0; i < handler.getSlots(); i++) {
-            if (!handler.getStackInSlot(i).isEmpty()) {
-                return false;
-            }
-        }
-        return true;
     }
 }

--- a/src/main/java/cn/foggyhillside/ends_delight/blockentitiy/EndStoveBlockEntity.java
+++ b/src/main/java/cn/foggyhillside/ends_delight/blockentitiy/EndStoveBlockEntity.java
@@ -77,7 +77,7 @@ public class EndStoveBlockEntity extends SyncedBlockEntity {
     public static void cookingTick(Level level, BlockPos pos, BlockState state, EndStoveBlockEntity stove) {
         boolean isStoveLit = (Boolean)state.getValue(EndStoveBlock.LIT);
         if (stove.isStoveBlockedAbove()) {
-            if (!ItemUtils.isInventoryEmpty(stove.inventory)) {
+            if (!isInventoryEmpty(stove.inventory)) {
                 ItemUtils.dropItems(level, pos, stove.inventory);
                 stove.inventoryChanged();
             }
@@ -236,5 +236,14 @@ public class EndStoveBlockEntity extends SyncedBlockEntity {
                 return 1;
             }
         };
+    }
+
+    private static boolean isInventoryEmpty(ItemStackHandler handler) {
+        for (int i = 0; i < handler.getSlots(); i++) {
+            if (!handler.getStackInSlot(i).isEmpty()) {
+                return false;
+            }
+        }
+        return true;
     }
 }


### PR DESCRIPTION
## Problem

When running End's Delight 2.5.1 with Farmer's Delight 1.3.2, the game crashes with `NoSuchMethodError`.

## Fix

Replaced the external API call with a private static helper method in `EndStoveBlockEntity` that performs the same inventory emptiness check inline, making the mod compatible with both old and new versions of Farmer's Delight.

### Changes

- `EndStoveBlockEntity.java`: Added `isInventoryEmpty(ItemStackHandler)` helper and replaced the `ItemUtils.isInventoryEmpty()` call with it (line 80)

## Testing

- [x] Compiles successfully against Farmer's Delight 1.3.2
- [x] Passed the test in Creative Mode and did not crash.

## Compiled
[ends_delight-2.5.1+forge.1.20.1-fixed-1.zip](https://github.com/user-attachments/files/29614962/ends_delight-2.5.1%2Bforge.1.20.1-fixed-1.zip)

